### PR TITLE
1.1.2 Plugin options change (removed precompile options) and added unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,3 +116,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed params `Helpers` type checker
 - Handlebars unit tests for templates
 - Fixed compiler and runtime bugs to pass all unit tests
+
+
+
+## [1.1.2](https://github.com/JohannIsaac/rollup-plugin-handlebars-compiler/pull/12)  2020-8-29
+
+### Changed
+
+- Removed precompile options as passable plugin options as these are currently unnecessary and may be unwanted (this can later be added as a feature)
+- Added README and test example of passing hbs files to the `partials` plugin options

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,9 @@ If you'd like to discuss a change you want to make before spending the time to w
 2. Run `npm install` in the root `rollup-plugin-handlebars-compiler` folder.
 3. Run `npm link && npm link rollup-plugin-handlebars-compiler` to link the current project to `node_modules`.
 4. If you are writing a change to submit as a pull request, make the changes in a new branch
+
+
+
+### Testing
+
+- Run `npm run test` to run unit tests and output test HTML results. HTML output results can be found in [./src/runtime-tests] in the `results` directory.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rollup-plugin-handlebars-compiler
-A Rollup plugin for to compile Handlebars templates to JavaScript functions with support for partials, helpers, and precompile options.
+A Rollup plugin to pre-compile Handlebars templates to JavaScript functions with support for partials, helpers, and compile options.
 
 See [Rollup](https://rollupjs.org/) and [Handlebars](http://handlebarsjs.com).
 
@@ -69,9 +69,9 @@ Output:
 
 ## Plugin Options
 
-In addition to the Handlebars Compiler plugin options, any `Handlebars.precompile()` option can also be passed.
+In addition to the Handlebars Compiler plugin options, any compile option can also be passed.
 
-See [Handlebars Precompile Options](https://handlebarsjs.com/api-reference/compilation.html)
+See [Handlebars Compile Options](https://handlebarsjs.com/api-reference/compilation.html)
 
 ```javascript
 export default {
@@ -99,12 +99,6 @@ export default {
             preventIndent, // By default, an indented partial-call causes the output of the whole partial being indented by the same amount. This can lead to unexpected behavior when the partial writes pre-tags. Setting this option to true will disable the auto-indent feature.
             ignoreStandalone, // Disables standalone tag removal when set to true. When set, blocks and partials that are on their own line will not remove the whitespace on that line.
             explicitPartialContext, // Disables implicit context for partials. When enabled, partials that are not passed a context value will execute against an empty object.
-
-
-            /* Handlebars pre-compile options */
-
-            srcName, // Passed to generate the source map for the input file. When run in this manner, the return structure is {code, map} with code containing the template definition and map containing the source map.
-            destName, // Optional parameter used in conjunction with srcName to provide a destination file name when generating source maps
         })
     ]
 }
@@ -219,11 +213,16 @@ export default {
         ...
         handlebarsCompiler({
             partials: {
-                titlePartial: `<h1>{{Title}}</h1>`
+                titlePartial: fs.readFileSync(path.join(__dirname, './src/title-partial.hbs')).toString()
             },
         })
     ]
 }
+```
+
+```hbs
+{{! src/title-partial.hbs }}
+<h1>{{Title}}</h1>
 ```
 
 Output:

--- a/dist/cjs/index.js
+++ b/dist/cjs/index.js
@@ -230,6 +230,10 @@ var pluginOptionsKeys = [
     'partials',
     'templateData',
 ];
+var preCompileOptions = [
+    'srcName',
+    'destName'
+];
 function parse(handlebarsPluginOptions) {
     var parsedOptions = {
         compileOptions: getCompileOptions(handlebarsPluginOptions),
@@ -245,7 +249,7 @@ function getCompileOptions(handlebarsPluginOptions) {
     try {
         for (var _b = __values(Object.entries(handlebarsPluginOptions)), _c = _b.next(); !_c.done; _c = _b.next()) {
             var _d = __read(_c.value, 2), key = _d[0], value = _d[1];
-            if (pluginOptionsKeys.includes(key))
+            if (pluginOptionsKeys.includes(key) || preCompileOptions.includes(key))
                 continue;
             compileOptions[key] = value;
         }
@@ -5936,7 +5940,6 @@ var HandlebarsCompiler = /** @class */ (function () {
     };
     HandlebarsCompiler.prototype.getTemplateSpecs = function (file) {
         var extname = path.extname(file);
-        var name = path.basename(file);
         var basename = path.basename(file, extname);
         var compiledTemplateData = this.partials.find(function (_a) {
             var _b = __read(_a, 1), partial = _b[0];
@@ -5948,10 +5951,8 @@ var HandlebarsCompiler = /** @class */ (function () {
         }
         var _a = __read(compiledTemplateData, 2); _a[0]; var compiledTemplate = _a[1];
         // Create a tree
-        var precompileOptions = Object.assign({}, this.compileOptions);
-        precompileOptions.srcName = name;
-        var tree = Handlebars.parse(compiledTemplate, { srcName: name });
-        var templateSpecs = Handlebars.precompile(tree, precompileOptions);
+        var tree = Handlebars.parse(compiledTemplate);
+        var templateSpecs = Handlebars.precompile(tree, this.compileOptions);
         return templateSpecs;
     };
     // Compile handlebars file to ESM
@@ -5959,7 +5960,7 @@ var HandlebarsCompiler = /** @class */ (function () {
         var compiledPartials = this.getCompiledPartials();
         var helpers = this.helpers;
         var templateData = this.templateData;
-        var _a = this.getTemplateSpecs(file), code = _a.code, map = _a.map;
+        var code = this.getTemplateSpecs(file);
         // Import this (partial) template and nested templates
         var body = "\n\t\t\timport Handlebars from 'handlebars/runtime.js';\n\t\t\tconst template = Handlebars.template(".concat(code, ");\n\t\t\t").concat(helpers.map(function (_a) {
             var _b = __read(_a, 2), helper = _b[0], fn = _b[1];
@@ -5970,7 +5971,7 @@ var HandlebarsCompiler = /** @class */ (function () {
         }).join('\n'), "\n\t\t\texport default (data, options) => {\n\t\t\t\tif (!data || typeof data !== 'object') {\n\t\t\t\t\tdata = {}\n\t\t\t\t}\n\t\t\t\tlet templateData = Object.assign({}, ").concat(JSON.stringify(templateData), ", data)\n\t\t\t\treturn template(templateData, options)\n\t\t\t};\n\t\t");
         // Format JS body before passing
         body = jsExports.js_beautify(body);
-        return { code: body, map: map };
+        return { code: body };
     };
     return HandlebarsCompiler;
 }());

--- a/dist/es/index.js
+++ b/dist/es/index.js
@@ -228,6 +228,10 @@ var pluginOptionsKeys = [
     'partials',
     'templateData',
 ];
+var preCompileOptions = [
+    'srcName',
+    'destName'
+];
 function parse(handlebarsPluginOptions) {
     var parsedOptions = {
         compileOptions: getCompileOptions(handlebarsPluginOptions),
@@ -243,7 +247,7 @@ function getCompileOptions(handlebarsPluginOptions) {
     try {
         for (var _b = __values(Object.entries(handlebarsPluginOptions)), _c = _b.next(); !_c.done; _c = _b.next()) {
             var _d = __read(_c.value, 2), key = _d[0], value = _d[1];
-            if (pluginOptionsKeys.includes(key))
+            if (pluginOptionsKeys.includes(key) || preCompileOptions.includes(key))
                 continue;
             compileOptions[key] = value;
         }
@@ -5934,7 +5938,6 @@ var HandlebarsCompiler = /** @class */ (function () {
     };
     HandlebarsCompiler.prototype.getTemplateSpecs = function (file) {
         var extname = path.extname(file);
-        var name = path.basename(file);
         var basename = path.basename(file, extname);
         var compiledTemplateData = this.partials.find(function (_a) {
             var _b = __read(_a, 1), partial = _b[0];
@@ -5946,10 +5949,8 @@ var HandlebarsCompiler = /** @class */ (function () {
         }
         var _a = __read(compiledTemplateData, 2); _a[0]; var compiledTemplate = _a[1];
         // Create a tree
-        var precompileOptions = Object.assign({}, this.compileOptions);
-        precompileOptions.srcName = name;
-        var tree = Handlebars.parse(compiledTemplate, { srcName: name });
-        var templateSpecs = Handlebars.precompile(tree, precompileOptions);
+        var tree = Handlebars.parse(compiledTemplate);
+        var templateSpecs = Handlebars.precompile(tree, this.compileOptions);
         return templateSpecs;
     };
     // Compile handlebars file to ESM
@@ -5957,7 +5958,7 @@ var HandlebarsCompiler = /** @class */ (function () {
         var compiledPartials = this.getCompiledPartials();
         var helpers = this.helpers;
         var templateData = this.templateData;
-        var _a = this.getTemplateSpecs(file), code = _a.code, map = _a.map;
+        var code = this.getTemplateSpecs(file);
         // Import this (partial) template and nested templates
         var body = "\n\t\t\timport Handlebars from 'handlebars/runtime.js';\n\t\t\tconst template = Handlebars.template(".concat(code, ");\n\t\t\t").concat(helpers.map(function (_a) {
             var _b = __read(_a, 2), helper = _b[0], fn = _b[1];
@@ -5968,7 +5969,7 @@ var HandlebarsCompiler = /** @class */ (function () {
         }).join('\n'), "\n\t\t\texport default (data, options) => {\n\t\t\t\tif (!data || typeof data !== 'object') {\n\t\t\t\t\tdata = {}\n\t\t\t\t}\n\t\t\t\tlet templateData = Object.assign({}, ").concat(JSON.stringify(templateData), ", data)\n\t\t\t\treturn template(templateData, options)\n\t\t\t};\n\t\t");
         // Format JS body before passing
         body = jsExports.js_beautify(body);
-        return { code: body, map: map };
+        return { code: body };
     };
     return HandlebarsCompiler;
 }());

--- a/lib/plugin-options.ts
+++ b/lib/plugin-options.ts
@@ -10,6 +10,11 @@ const pluginOptionsKeys = [
     'templateData',
 ]
 
+const preCompileOptions = [
+    'srcName',
+    'destName'
+]
+
 function parse(handlebarsPluginOptions: HandlebarsPluginOptions): ParsedOptions.IParsedOptions {
     const parsedOptions: ParsedOptions.IParsedOptions = {
         compileOptions: getCompileOptions(handlebarsPluginOptions),
@@ -20,10 +25,10 @@ function parse(handlebarsPluginOptions: HandlebarsPluginOptions): ParsedOptions.
     return parsedOptions
 }
 
-function getCompileOptions(handlebarsPluginOptions: PluginOptions.TemplateData): CompileOptions {
+function getCompileOptions(handlebarsPluginOptions: HandlebarsPluginOptions): CompileOptions {
     const compileOptions = {}
     for (const [key, value] of Object.entries(handlebarsPluginOptions)) {
-        if (pluginOptionsKeys.includes(key)) continue
+        if (pluginOptionsKeys.includes(key) || preCompileOptions.includes(key)) continue
         compileOptions[key] = value
     }
     return compileOptions

--- a/lib/types/handlebars/index.ts
+++ b/lib/types/handlebars/index.ts
@@ -1,7 +1,10 @@
-export interface TemplateSpecification {
-    code?: string;
-    map?: string;
-    [key: string | number]: any;
+export type TemplateSourceMap = {
+    code: string;
+    map: string;
 }
 
-export interface CompileResult extends TemplateSpecification {}
+export type TemplateSpecification = string | TemplateSourceMap
+
+export type CompileResult = {
+    code: string
+}

--- a/lib/types/plugin-options/parsed.ts
+++ b/lib/types/plugin-options/parsed.ts
@@ -7,7 +7,7 @@ export type Helpers = Helper[]
 export type TemplateData = object
 
 export interface IParsedOptions {
-    partials: SourceData[]
+    partials: Partials
     helpers: Helpers
     templateData: TemplateData
     compileOptions: CompileOptions

--- a/lib/types/source-map/index.ts
+++ b/lib/types/source-map/index.ts
@@ -1,2 +1,5 @@
-export type SourceData = [string, string]
-export type SourceDataMap = Map<string, string>
+type SourceFile = string
+type SourceContent = string
+
+export type SourceData = [SourceFile, SourceContent]
+export type SourceDataMap = Map<SourceFile, SourceContent>

--- a/runtime-tests/runtime.test.js
+++ b/runtime-tests/runtime.test.js
@@ -121,6 +121,17 @@ describe('handlebars rutime', () => {
         )
     })
     
+    it('should allow partials to be passed through the plugin options', async () => {
+        await testTemplate(
+            './with-plugin-partial.hbs',
+            TEST_TEMPLATE_DATA,
+            async (err, output) => {
+                const catchOutput = output.indexOf("<p>another: Description</p>") >= 0
+                expect(catchOutput).toBe(true)
+            }
+        )
+    })
+    
     it('should allow partials to find multiple paths', async () => {
         await testTemplate(
             './with-dir-partials.hbs',

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -63,6 +63,7 @@ function testTemplate(template: string, pluginOptions: HandlebarsPluginOptions, 
 }
 
 describe('Handlebars Transformer', () => {
+
     it('should load simple handlebars templates', () => {
 
         const pluginOptions: HandlebarsPluginOptions = {}
@@ -72,7 +73,6 @@ describe('Handlebars Transformer', () => {
             pluginOptions,
             async (err, output) => {
                 expect(output).toHaveProperty('code')
-                expect(output).toHaveProperty('map')
             }
         )
     })
@@ -147,6 +147,24 @@ describe('Handlebars Transformer', () => {
             pluginOptions,
             async (err, output) => {
                 const catchOutput = output.code.indexOf("Handlebars.registerHelper('description") >= 0
+                expect(catchOutput).toBe(true)
+            }
+        )
+    })
+
+    it('should allow partials to be passed through the plugin options', async () => {
+
+        const pluginOptions: HandlebarsPluginOptions = {
+            partials: {
+                otherPartial: fs.readFileSync(path.join(__dirname, './partialDirs/anotherDir/otherPartial.hbs')).toString()
+            }
+        }
+
+        testTemplate(
+            './with-plugin-partial.hbs',
+            pluginOptions,
+            async (err, output) => {
+                const catchOutput = output?.code.indexOf("Handlebars.registerPartial('otherPartial") >= 0
                 expect(catchOutput).toBe(true)
             }
         )

--- a/tests/with-plugin-partial.hbs
+++ b/tests/with-plugin-partial.hbs
@@ -1,0 +1,1 @@
+{{> otherPartial description=description }}


### PR DESCRIPTION
- Removed precompile options as passable plugin options as these are currently unnecessary and may be unwanted (this can later be added as a feature)
- Added README and test example of passing hbs files to the `partials` plugin options